### PR TITLE
- feature: add shinkai tool generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ async fn main() {
     assert_eq!(run_result.data["message"], "echoing: new york");
 }
 ```
+
+## Adding a New Shinkai Tool
+
+To add a new Shinkai tool to this project, follow these simple steps:
+
+1. **Run the Hygen command**: Run `npx hygen shinkai-tool new` to create a new tool. This command will guide you through the process of creating a new tool, including setting up the directory structure and generating the necessary files.
+
+That's it! With this single command, you'll have a new Shinkai tool set up and ready to go.

--- a/_templates/shinkai-tool/new/built_in_tools.rs.t
+++ b/_templates/shinkai-tool/new/built_in_tools.rs.t
@@ -1,0 +1,15 @@
+---
+inject: true
+to: libs/shinkai-tools-runner/src/built_in_tools.rs
+before: "// ntim:"
+---
+        m.insert(
+            "shinkai-tool-<%= name %>",
+            &*Box::leak(Box::new(
+                serde_json::from_str::<ToolDefinition>(include_str!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/tools/shinkai-tool-<%= name %>/definition.json"
+                )))
+                .unwrap(),
+            )),
+        );

--- a/_templates/shinkai-tool/new/index.ts.t
+++ b/_templates/shinkai-tool/new/index.ts.t
@@ -1,0 +1,45 @@
+---
+to: apps/shinkai-tool-<%= name %>/src/index.ts
+---
+import { BaseTool, RunResult } from '@shinkai_protocol/shinkai-tools-builder';
+import { ToolDefinition } from 'libs/shinkai-tools-builder/src/tool-definition';
+
+type Config = {};
+type Params = {
+  message: string;
+};
+type Result = { message: string };
+export class Tool extends BaseTool<Config, Params, Result> {
+  definition: ToolDefinition<Config, Params, Result> = {
+    id: 'shinkai-tool-<%= name %>',
+    name: 'Shinkai: <%= name %>',
+    description: 'New <%= name %> tool from template',
+    author: 'Shinkai',
+    keywords: ['<%= name %>', 'shinkai'],
+    configurations: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    parameters: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+      },
+      required: ['message'],
+    },
+    result: {
+        type: 'object',
+        properties: {
+          message: { type: 'string' }
+        },
+        required: ['message']
+      },
+  };
+
+  async run(params: Params): Promise<RunResult<Result>> {
+    const message = `hello world <%= name %>`;
+    console.log(message);
+    return Promise.resolve({ data: { message } });
+  }
+}

--- a/_templates/shinkai-tool/new/packaje.json.t
+++ b/_templates/shinkai-tool/new/packaje.json.t
@@ -1,0 +1,7 @@
+---
+to: apps/shinkai-tool-<%= name %>/package.json
+---
+{
+  "name": "@shinkai_protocol/shinkai-tool-<%= name %>",
+  "type": "commonjs"
+}

--- a/_templates/shinkai-tool/new/project.json.t
+++ b/_templates/shinkai-tool/new/project.json.t
@@ -1,0 +1,38 @@
+---
+to: apps/shinkai-tool-<%= name %>/project.json
+---
+{
+  "name": "@shinkai_protocol/shinkai-tool-<%= name %>",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/shinkai-tool-<%= name %>/src",
+  "projectType": "library",
+  "tags": ["tool"],
+  "targets": {
+    "build": {
+      "executor": "@nx/webpack:webpack",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "compiler": "tsc",
+        "outputPath": "dist/apps/shinkai-tool-<%= name %>",
+        "main": "apps/shinkai-tool-<%= name %>/src/index.ts",
+        "tsConfig": "apps/shinkai-tool-<%= name %>/tsconfig.app.json",
+        "webpackConfig": "apps/shinkai-tool-<%= name %>/webpack.config.ts"
+      },
+      "configurations": {
+        "development": {},
+        "production": {}
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "apps/shinkai-tool-<%= name %>/**/*.ts",
+          "apps/shinkai-tool-<%= name %>/package.json"
+        ]
+      }
+    }
+  }
+}

--- a/_templates/shinkai-tool/new/prompt.js
+++ b/_templates/shinkai-tool/new/prompt.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    type: 'input',
+    name: 'name',
+    message: "What's your shinkai-tool name?",
+  },
+];

--- a/_templates/shinkai-tool/new/tsconfig.app.json.t
+++ b/_templates/shinkai-tool/new/tsconfig.app.json.t
@@ -1,0 +1,7 @@
+---
+to: apps/shinkai-tool-<%= name %>/tsconfig.app.json
+---
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*.ts"]
+}

--- a/_templates/shinkai-tool/new/tsconfig.json.t
+++ b/_templates/shinkai-tool/new/tsconfig.json.t
@@ -1,0 +1,13 @@
+---
+to: apps/shinkai-tool-<%= name %>/tsconfig.json
+---
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+
+  },
+  "include": [
+    "./src/**/*.ts",
+    "webpack.config.ts"
+  ],
+}

--- a/_templates/shinkai-tool/new/webpack.config.ts.t
+++ b/_templates/shinkai-tool/new/webpack.config.ts.t
@@ -1,0 +1,20 @@
+---
+to: apps/shinkai-tool-<%= name %>/webpack.config.ts
+---
+import * as path from 'path';
+
+import { composePlugins, withNx } from '@nx/webpack';
+import { merge } from 'lodash';
+
+import { withToolWebpackConfig } from '@shinkai_protocol/shinkai-tools-bundler';
+
+module.exports = composePlugins(withNx(), (config, { options, context }) => {
+  return merge(
+    config,
+    withToolWebpackConfig({
+      entry: path.join(__dirname, 'src/index.ts'),
+      outputPath: path.join(__dirname, '../../dist/apps/shinkai-tool-<%= name %>'),
+      tsConfigFile: path.join(__dirname, 'tsconfig.app.json'),
+    }),
+  );
+});

--- a/apps/shinkai-tool-download-page/webpack.config.ts
+++ b/apps/shinkai-tool-download-page/webpack.config.ts
@@ -10,7 +10,7 @@ module.exports = composePlugins(withNx(), (config, { options, context }) => {
     config,
     withToolWebpackConfig({
       entry: path.join(__dirname, 'src/index.ts'),
-      outputPath: path.join(__dirname, '../../dist/apps/shinkai-tool-echo'),
+      outputPath: path.join(__dirname, '../../dist/apps/shinkai-tool-download-page'),
       tsConfigFile: path.join(__dirname, 'tsconfig.app.json'),
     }),
   );

--- a/apps/shinkai-tool-foobar/package.json
+++ b/apps/shinkai-tool-foobar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@shinkai_protocol/shinkai-tool-foobar",
+  "type": "commonjs"
+}

--- a/apps/shinkai-tool-foobar/project.json
+++ b/apps/shinkai-tool-foobar/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "@shinkai_protocol/shinkai-tool-foobar",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/shinkai-tool-foobar/src",
+  "projectType": "library",
+  "tags": ["tool"],
+  "targets": {
+    "build": {
+      "executor": "@nx/webpack:webpack",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "compiler": "tsc",
+        "outputPath": "dist/apps/shinkai-tool-foobar",
+        "main": "apps/shinkai-tool-foobar/src/index.ts",
+        "tsConfig": "apps/shinkai-tool-foobar/tsconfig.app.json",
+        "webpackConfig": "apps/shinkai-tool-foobar/webpack.config.ts"
+      },
+      "configurations": {
+        "development": {},
+        "production": {}
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": [
+          "apps/shinkai-tool-foobar/**/*.ts",
+          "apps/shinkai-tool-foobar/package.json"
+        ]
+      }
+    }
+  }
+}

--- a/apps/shinkai-tool-foobar/src/index.ts
+++ b/apps/shinkai-tool-foobar/src/index.ts
@@ -1,0 +1,42 @@
+import { BaseTool, RunResult } from '@shinkai_protocol/shinkai-tools-builder';
+import { ToolDefinition } from 'libs/shinkai-tools-builder/src/tool-definition';
+
+type Config = {};
+type Params = {
+  message: string;
+};
+type Result = { message: string };
+export class Tool extends BaseTool<Config, Params, Result> {
+  definition: ToolDefinition<Config, Params, Result> = {
+    id: 'shinkai-tool-foobar',
+    name: 'Shinkai: foobar',
+    description: 'New foobar tool from template',
+    author: 'Shinkai',
+    keywords: ['foobar', 'shinkai'],
+    configurations: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    parameters: {
+      type: 'object',
+      properties: {
+        message: { type: 'string' },
+      },
+      required: ['message'],
+    },
+    result: {
+        type: 'object',
+        properties: {
+          message: { type: 'string' }
+        },
+        required: ['message']
+      },
+  };
+
+  async run(params: Params): Promise<RunResult<Result>> {
+    const message = `hello world foobar`;
+    console.log(message);
+    return Promise.resolve({ data: { message } });
+  }
+}

--- a/apps/shinkai-tool-foobar/tsconfig.app.json
+++ b/apps/shinkai-tool-foobar/tsconfig.app.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./src/**/*.ts"]
+}

--- a/apps/shinkai-tool-foobar/tsconfig.json
+++ b/apps/shinkai-tool-foobar/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+
+  },
+  "include": [
+    "./src/**/*.ts",
+    "webpack.config.ts"
+  ],
+}

--- a/apps/shinkai-tool-foobar/webpack.config.ts
+++ b/apps/shinkai-tool-foobar/webpack.config.ts
@@ -1,0 +1,17 @@
+import * as path from 'path';
+
+import { composePlugins, withNx } from '@nx/webpack';
+import { merge } from 'lodash';
+
+import { withToolWebpackConfig } from '@shinkai_protocol/shinkai-tools-bundler';
+
+module.exports = composePlugins(withNx(), (config, { options, context }) => {
+  return merge(
+    config,
+    withToolWebpackConfig({
+      entry: path.join(__dirname, 'src/index.ts'),
+      outputPath: path.join(__dirname, '../../dist/apps/shinkai-tool-foobar'),
+      tsConfigFile: path.join(__dirname, 'tsconfig.app.json'),
+    }),
+  );
+});

--- a/libs/shinkai-tools-runner/src/built_in_tools.rs
+++ b/libs/shinkai-tools-runner/src/built_in_tools.rs
@@ -66,6 +66,17 @@ lazy_static! {
                 .unwrap(),
             )),
         );
+        m.insert(
+            "shinkai-tool-foobar",
+            &*Box::leak(Box::new(
+                serde_json::from_str::<ToolDefinition>(include_str!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/tools/shinkai-tool-foobar/definition.json"
+                )))
+                .unwrap(),
+            )),
+        );
+        // ntim: New tools will be inserted here, don't remove this comment
         m
     };
 }

--- a/libs/shinkai-tools-runner/src/lib.test.rs
+++ b/libs/shinkai-tools-runner/src/lib.test.rs
@@ -98,3 +98,20 @@ async fn shinkai_tool_web3_eth_uniswap() {
         .await;
     assert!(run_result.is_ok());
 }
+
+#[tokio::test]
+async fn shinkai_tool_download_page() {
+    let tool_definition = get_tool("shinkai-tool-download-page").unwrap();
+    let mut tool = Tool::new();
+    let _ = tool
+        .load_from_code(&tool_definition.code.clone().unwrap(), "")
+        .await;
+    let run_result = tool
+        .run(
+            r#"{
+    "url": "https://shinkai.com"
+}"#,
+        )
+        .await;
+    assert!(run_result.is_ok());
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-simple-import-sort": "^12.1.0",
+        "hygen": "^6.2.11",
         "lodash": "^4.17.21",
         "nx": "19.3.1",
         "prettier": "^3.3.2",
@@ -4609,6 +4610,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -4655,6 +4666,32 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "node_modules/chokidar": {
@@ -4925,6 +4962,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==",
+      "dev": true,
+      "dependencies": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
       }
     },
     "node_modules/content-disposition": {
@@ -5731,6 +5778,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degit": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
+      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "dev": true,
+      "bin": {
+        "degit": "degit"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -5916,6 +5975,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0"
       }
     },
     "node_modules/dotenv": {
@@ -7674,6 +7742,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7845,6 +7923,51 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hygen": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/hygen/-/hygen-6.2.11.tgz",
+      "integrity": "sha512-t6/zLI2XozP5gvV74nnl8LZSbwpVNFUkUs/O9DwuOdiiBbws5k4AQNVwKZ9FGzcKjdJ5EBBYkVzlcUHkLyY0FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.19",
+        "chalk": "^4.1.2",
+        "change-case": "^3.1.0",
+        "debug": "^4.3.3",
+        "degit": "^2.8.4",
+        "ejs": "^3.1.6",
+        "enquirer": "^2.3.6",
+        "execa": "^5.0.0",
+        "front-matter": "^4.0.2",
+        "fs-extra": "^10.0.0",
+        "ignore-walk": "^4.0.1",
+        "inflection": "^1.12.0",
+        "ora": "^5.0.0",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "hygen": "dist/bin.js"
+      }
+    },
+    "node_modules/hygen/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/hygen/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -7896,6 +8019,40 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/ignore-walk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
+      "integrity": "sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/ignore-walk/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/image-size": {
@@ -7960,6 +8117,15 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.4.0"
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -8183,6 +8349,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha512-+5A1e/WJpLLXZEDlgz4G//WYSHyQBD32qa4Jd3Lw06qQlv3fJHnp3YIHjTQSGzHMgzmVKz2ZP3rBxTHkPw/lxA==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -8350,6 +8525,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==",
+      "dev": true,
+      "dependencies": {
+        "upper-case": "^1.1.0"
       }
     },
     "node_modules/is-weakref": {
@@ -8852,6 +9036,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==",
+      "dev": true
+    },
+    "node_modules/lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^1.1.2"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9292,6 +9491,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -9728,6 +9936,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9803,6 +10020,25 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha512-Ou0N05MioItesaLr9q8TtHVWmJ6fxWdqKB2RohFmNWVyJ+2zeKIeDNWAN6B/Pe7wpzWChhZX6nONYmOnMeJQ/Q==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0"
       }
     },
     "node_modules/path-exists": {
@@ -11323,6 +11559,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -11552,6 +11798,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0"
       }
     },
     "node_modules/sockjs": {
@@ -11975,6 +12230,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==",
+      "dev": true,
+      "dependencies": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -12121,6 +12386,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==",
+      "dev": true,
+      "dependencies": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -12549,6 +12824,21 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==",
+      "dev": true
+    },
+    "node_modules/upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha512-wINKYvI3Db8dtjikdAqoBbZoP6Q+PZUyfMR7pmwHzjC2quzSkUq5DmPrTtPEqHaz8AGtmsB4TqwapMTM1QAQOQ==",
+      "dev": true,
+      "dependencies": {
+        "upper-case": "^1.1.1"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-simple-import-sort": "^12.1.0",
+    "hygen": "^6.2.11",
     "lodash": "^4.17.21",
     "nx": "19.3.1",
     "prettier": "^3.3.2",


### PR DESCRIPTION
## Adding a New Shinkai Tool

To add a new Shinkai tool to this project, follow these simple steps:

1. **Run the Hygen command**: Run `npx hygen shinkai-tool new` to create a new tool. This command will guide you through the process of creating a new tool, including setting up the directory structure and generating the necessary files.

That's it! With this single command, you'll have a new Shinkai tool set up and ready to go.
