### PR TITLE
- feature: added mount feature for assets and mount folder

### DIFF
--- a/libs/shinkai-tools-runner/project.json
+++ b/libs/shinkai-tools-runner/project.json
@@ -38,7 +38,7 @@
       "defaultConfiguration": "development",
       "options": {
         "cwd": "libs/shinkai-tools-runner",
-        "command": "cargo test --features=built-in-tools -- --test-threads=1"
+        "command": "cargo test --features=built-in-tools"
       },
       "configurations": {
         "development": {},

--- a/libs/shinkai-tools-runner/src/built_in_tools.test.rs
+++ b/libs/shinkai-tools-runner/src/built_in_tools.test.rs
@@ -4,6 +4,10 @@ use crate::built_in_tools::{get_tool, get_tools};
 
 #[tokio::test]
 async fn get_tools_all_load() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
     let tools = get_tools();
     for (tool_name, tool_definition) in tools {
         println!("creating tool instance for {}", tool_name);

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -100,66 +100,6 @@ impl DenoExecutionStorage {
         Ok(())
     }
 
-    pub fn get_relative_code(&self) -> anyhow::Result<String> {
-        self.code
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
-    pub fn get_relative_code_entrypoint(&self) -> anyhow::Result<String> {
-        self.code_entrypoint
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
-    pub fn get_relative_deno_cache(&self) -> anyhow::Result<String> {
-        self.deno_cache
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
-    pub fn get_relative_home(&self) -> anyhow::Result<String> {
-        self.home
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
-    pub fn get_relative_assets(&self) -> anyhow::Result<String> {
-        self.assets
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
-    pub fn get_relative_mount(&self) -> anyhow::Result<String> {
-        self.mount
-            .strip_prefix(&self.root)
-            .map(|p| p.to_string_lossy().to_string())
-            .map_err(|e| {
-                log::error!("failed to get relative path: {}", e);
-                anyhow::anyhow!("failed to get relative path: {}", e)
-            })
-    }
-
     pub fn append_log(&self, log: &str) -> anyhow::Result<()> {
         let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
         let log_line = format!(
@@ -176,6 +116,17 @@ impl DenoExecutionStorage {
             })?;
         file.write_all(log_line.as_bytes())?;
         Ok(())
+    }
+
+    pub fn relative_to_root(&self, path: PathBuf) -> String {
+        let path = path.strip_prefix(&self.root).unwrap();
+        self.normalize(path.to_path_buf())
+    }
+
+    pub fn normalize(&self, path: PathBuf) -> String {
+        path.to_string_lossy()
+            .replace("\\\\?\\", "")
+            .replace("\\", "/")
     }
 }
 

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -3,9 +3,9 @@ use std::{
     path::{self, PathBuf},
 };
 
-use nanoid::nanoid;
-
 use super::execution_context::ExecutionContext;
+use super::path_buf_ext::PathBufExt;
+use nanoid::nanoid;
 
 #[derive(Default, Clone)]
 pub struct DenoExecutionStorage {
@@ -120,13 +120,7 @@ impl DenoExecutionStorage {
 
     pub fn relative_to_root(&self, path: PathBuf) -> String {
         let path = path.strip_prefix(&self.root).unwrap();
-        self.normalize(path.to_path_buf())
-    }
-
-    pub fn normalize(&self, path: PathBuf) -> String {
-        path.to_string_lossy()
-            .replace("\\\\?\\", "")
-            .replace("\\", "/")
+        path.to_path_buf().as_normalized_string()
     }
 }
 

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -1,6 +1,6 @@
 use std::{
     io::Write,
-    path::{self, Path, PathBuf},
+    path::{self, PathBuf},
 };
 
 use nanoid::nanoid;
@@ -19,6 +19,8 @@ pub struct DenoExecutionStorage {
     pub logs: PathBuf,
     pub log_file: PathBuf,
     pub home: PathBuf,
+    pub assets: PathBuf,
+    pub mount: PathBuf,
 }
 
 impl DenoExecutionStorage {
@@ -46,6 +48,8 @@ impl DenoExecutionStorage {
             logs: logs.clone(),
             log_file,
             home: root.join("home"),
+            assets: root.join("assets"),
+            mount: root.join("mount"),
         }
     }
 
@@ -57,6 +61,8 @@ impl DenoExecutionStorage {
             &self.deno_cache,
             &self.logs,
             &self.home,
+            &self.assets,
+            &self.mount,
         ] {
             log::info!("creating directory: {}", dir.display());
             std::fs::create_dir_all(dir).map_err(|e| {
@@ -94,6 +100,16 @@ impl DenoExecutionStorage {
         Ok(())
     }
 
+    pub fn get_relative_code(&self) -> anyhow::Result<String> {
+        self.code
+            .strip_prefix(&self.root)
+            .map(|p| p.to_string_lossy().to_string())
+            .map_err(|e| {
+                log::error!("failed to get relative path: {}", e);
+                anyhow::anyhow!("failed to get relative path: {}", e)
+            })
+    }
+
     pub fn get_relative_code_entrypoint(&self) -> anyhow::Result<String> {
         self.code_entrypoint
             .strip_prefix(&self.root)
@@ -106,6 +122,36 @@ impl DenoExecutionStorage {
 
     pub fn get_relative_deno_cache(&self) -> anyhow::Result<String> {
         self.deno_cache
+            .strip_prefix(&self.root)
+            .map(|p| p.to_string_lossy().to_string())
+            .map_err(|e| {
+                log::error!("failed to get relative path: {}", e);
+                anyhow::anyhow!("failed to get relative path: {}", e)
+            })
+    }
+
+    pub fn get_relative_home(&self) -> anyhow::Result<String> {
+        self.home
+            .strip_prefix(&self.root)
+            .map(|p| p.to_string_lossy().to_string())
+            .map_err(|e| {
+                log::error!("failed to get relative path: {}", e);
+                anyhow::anyhow!("failed to get relative path: {}", e)
+            })
+    }
+
+    pub fn get_relative_assets(&self) -> anyhow::Result<String> {
+        self.assets
+            .strip_prefix(&self.root)
+            .map(|p| p.to_string_lossy().to_string())
+            .map_err(|e| {
+                log::error!("failed to get relative path: {}", e);
+                anyhow::anyhow!("failed to get relative path: {}", e)
+            })
+    }
+
+    pub fn get_relative_mount(&self) -> anyhow::Result<String> {
+        self.mount
             .strip_prefix(&self.root)
             .map(|p| p.to_string_lossy().to_string())
             .map_err(|e| {

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.test.rs
@@ -9,8 +9,7 @@ async fn test_execution_storage_init() {
         .is_test(true)
         .try_init();
 
-    let test_dir =
-        std::path::PathBuf::from("./shinkai-tools-runner-execution-storage/test-execution-storage");
+    let test_dir = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
     let storage = DenoExecutionStorage::new(ExecutionContext {
         storage: test_dir.clone(),
         ..Default::default()
@@ -29,9 +28,6 @@ async fn test_execution_storage_init() {
     // Verify code file was written correctly
     let code_contents = std::fs::read_to_string(storage.code_entrypoint.clone()).unwrap();
     assert_eq!(code_contents, test_code);
-
-    // Clean up test directory
-    std::fs::remove_dir_all(test_dir).unwrap();
 }
 
 #[tokio::test]
@@ -41,8 +37,7 @@ async fn test_execution_storage_clean_cache() {
         .is_test(true)
         .try_init();
 
-    let test_dir =
-        std::path::PathBuf::from("./shinkai-tools-runner-execution-storage/test-clean-cache");
+    let test_dir = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
     let storage = DenoExecutionStorage::new(ExecutionContext {
         storage: test_dir.clone(),
         ..Default::default()
@@ -64,7 +59,4 @@ async fn test_execution_storage_clean_cache() {
     assert!(!test_cache_file.exists());
     assert!(storage.deno_cache.exists()); // Directory should still exist but be empty
     assert!(std::fs::read_dir(&storage.deno_cache).unwrap().count() == 0);
-
-    // Clean up test directory
-    std::fs::remove_dir_all(test_dir).unwrap();
 }

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
@@ -54,9 +54,11 @@ async fn test_write_forbidden_folder() {
         .is_test(true)
         .try_init();
 
-    std::env::set_var("CI_FORCE_DENO_IN_HOST", "true");
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        force_deno_in_host: true,
+        ..Default::default()
+    });
 
-    let mut deno_runner = DenoRunner::default();
     let code = r#"
       try {
         await Deno.writeTextFile("/test.txt", "This should fail");
@@ -67,12 +69,10 @@ async fn test_write_forbidden_folder() {
         throw e;
       }
     "#;
-
     let result = deno_runner.run(code, None, None).await.map_err(|e| {
         log::error!("Failed to run deno code: {}", e);
         e
     });
-
     assert!(result.is_err());
 }
 

--- a/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
@@ -7,6 +7,7 @@ pub struct DenoRunnerOptions {
     pub context: ExecutionContext,
     pub deno_binary_path: PathBuf,
     pub deno_image_name: String,
+    pub force_deno_in_host: bool,
 }
 
 impl Default for DenoRunnerOptions {
@@ -19,6 +20,9 @@ impl Default for DenoRunnerOptions {
             } else {
                 "./shinkai-tools-runner-resources/deno"
             }),
+            force_deno_in_host: std::env::var("CI_FORCE_DENO_IN_HOST")
+                .map(|val| val == "true")
+                .unwrap_or(false),
         }
     }
 }

--- a/libs/shinkai-tools-runner/src/tools/execution_context.rs
+++ b/libs/shinkai-tools-runner/src/tools/execution_context.rs
@@ -6,6 +6,8 @@ pub struct ExecutionContext {
     pub execution_id: String,
     pub code_id: String,
     pub storage: PathBuf,
+    pub assets: Vec<PathBuf>,
+    pub mount_files: Vec<PathBuf>,
 }
 
 impl Default for ExecutionContext {
@@ -15,6 +17,8 @@ impl Default for ExecutionContext {
             execution_id: nanoid::nanoid!(),
             code_id: nanoid::nanoid!(),
             storage: PathBuf::from("./shinkai-tools-runner-execution-storage"),
+            assets: Vec::new(),
+            mount_files: Vec::new(),
         }
     }
 }

--- a/libs/shinkai-tools-runner/src/tools/mod.rs
+++ b/libs/shinkai-tools-runner/src/tools/mod.rs
@@ -7,3 +7,4 @@ pub mod execution_error;
 pub mod run_result;
 pub mod tool;
 pub mod tool_definition;
+mod path_buf_ext;

--- a/libs/shinkai-tools-runner/src/tools/path_buf_ext.rs
+++ b/libs/shinkai-tools-runner/src/tools/path_buf_ext.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+pub trait PathBufExt {
+    fn as_normalized_string(&self) -> String;
+}
+
+impl PathBufExt for PathBuf {
+    fn as_normalized_string(&self) -> String {
+        self.to_string_lossy()
+            .replace("\\\\?\\", "")
+            .replace("\\", "/")
+    }
+}

--- a/libs/shinkai-tools-runner/src/tools/tool.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.rs
@@ -90,8 +90,9 @@ impl Tool {
             const parameters = JSON.parse('{}');
 
             const result = await run(configurations, parameters);
+            const adaptedResult = result === undefined ? null : result;
             console.log("<shinkai-tool-result>");
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(adaptedResult));
             console.log("</shinkai-tool-result>");
         "#,
             &self.code.to_string(),

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -239,7 +239,6 @@ async fn test_mount_file_in_mount() {
         }
     "#;
 
-    // Run the code to ensure dependencies are downloaded
     let tool = Tool::new(
         js_code.to_string(),
         serde_json::Value::Null,
@@ -274,7 +273,6 @@ async fn test_mount_and_edit_file_in_mount() {
         .is_test(true)
         .try_init();
 
-    // Create test file with content
     let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
@@ -288,7 +286,6 @@ async fn test_mount_and_edit_file_in_mount() {
         }
     "#;
 
-    // Run the code to ensure dependencies are downloaded
     let tool = Tool::new(
         js_code.to_string(),
         serde_json::Value::Null,
@@ -315,7 +312,6 @@ async fn test_mount_and_edit_file_in_mount() {
     assert!(result.is_ok());
     assert!(result.unwrap().data == serde_json::Value::Null);
 
-    // Verify the temp file content was updated to "2"
     let content = std::fs::read_to_string(&test_file_path).unwrap();
     assert_eq!(content, "2");
 }
@@ -327,7 +323,6 @@ async fn test_mount_file_in_assets() {
         .is_test(true)
         .try_init();
 
-    // Create test file with content
     let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
@@ -342,7 +337,6 @@ async fn test_mount_file_in_assets() {
         }
     "#;
 
-    // Run the code to ensure dependencies are downloaded
     let tool = Tool::new(
         js_code.to_string(),
         serde_json::Value::Null,
@@ -377,7 +371,6 @@ async fn test_fail_when_try_write_assets() {
         .is_test(true)
         .try_init();
 
-    // Create test file with content
     let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
@@ -392,7 +385,6 @@ async fn test_fail_when_try_write_assets() {
     "#;
 
     let context_id = format!("test-mount-file-in-assets-{}", nanoid::nanoid!());
-    // Run the code to ensure dependencies are downloaded
     let tool = Tool::new(
         js_code.to_string(),
         serde_json::Value::Null,

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use serde_json::Value;
 
@@ -207,7 +210,6 @@ async fn test_file_persistence_in_home() {
     let result = tool.run(None, serde_json::Value::Null, None).await.unwrap();
     assert_eq!(result.data["success"], true);
 
-    // Check if file exists in the execution storage directory
     let file_path = execution_storage.join(format!("{}/home/test.txt", context_id));
     assert!(file_path.exists());
 }
@@ -219,8 +221,11 @@ async fn test_mount_file_in_mount() {
         .is_test(true)
         .try_init();
 
-    // Create test file with content
-    let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let test_file_path = PathBuf::from(format!(
+        "././shinkai-tools-runner-execution-storage/temp-test-files/{}",
+        nanoid::nanoid!()
+    ));
+    std::fs::create_dir_all(test_file_path.parent().unwrap()).unwrap();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
 


### PR DESCRIPTION
# Add Asset and Mount File Support for Deno Tools (docker implementation)

This PR adds support for mounting files in two ways:
- Read-only assets via `context.assets`
- Read-write mount files via `context.mount_files`

The implementation includes:
- New directories in execution storage for assets and mount points
- Docker mount configuration for file access
- Tests validating both read-only and read-write file operations

This enables tools to work with external files in a controlled manner, with clear separation between read-only assets and writable mount points.