### PR TITLE
feat: Set up new Docker image with Google Chrome

### DIFF
--- a/apps/shinkai-tool-aave-loan-requester/src/index.ts
+++ b/apps/shinkai-tool-aave-loan-requester/src/index.ts
@@ -19,8 +19,13 @@ export const run: Run<Configurations, Parameters, Result> = async (
   configurations,
   parameters,
 ): Promise<Result> => {
+  const chromePath =
+    configurations?.chromePath ||
+    process.env.CHROME_PATH ||
+    chromePaths.chrome ||
+    chromePaths.chromium;
   const browser = await playwright['chromium'].launch({
-    executablePath: configurations?.chromePath || chromePaths.chrome,
+    executablePath: chromePath,
   });
   const context = await browser.newContext({
     viewport: { width: 1280, height: 800 }, // Set viewport size

--- a/apps/shinkai-tool-defillama-tvl-rankings/src/index.ts
+++ b/apps/shinkai-tool-defillama-tvl-rankings/src/index.ts
@@ -203,7 +203,11 @@ export const run: Run<Config, Params, Result> = (
   configurations: Config,
   params: Params,
 ): Promise<Result> => {
-  const chromePath = configurations?.chromePath || chromePaths.chrome;
+  const chromePath =
+    configurations?.chromePath ||
+    process.env.CHROME_PATH ||
+    chromePaths.chrome ||
+    chromePaths.chromium;
   return withPage(chromePath, async (page) => {
     const categories = await getCategories(page);
 

--- a/apps/shinkai-tool-perplexity/src/index.ts
+++ b/apps/shinkai-tool-perplexity/src/index.ts
@@ -21,8 +21,13 @@ export const run: Run<Configurations, Parameters, Result> = async (
       navigationTimeout: 60 * 1000,
     },
   });
+  const chromePath =
+    configurations?.chromePath ||
+    process.env.CHROME_PATH ||
+    chromePaths.chrome ||
+    chromePaths.chromium;
   const browser = await playwright['chromium'].launch({
-    executablePath: configurations?.chromePath || chromePaths.chrome,
+    executablePath: chromePath,
   });
   const context = await browser.newContext({
     viewport: { width: 1280, height: 800 }, // Set viewport size

--- a/apps/shinkai-tool-playwright-example/src/index.ts
+++ b/apps/shinkai-tool-playwright-example/src/index.ts
@@ -16,9 +16,10 @@ export const run: Run<Configurations, Parameters, Result> = async (
 ): Promise<Result> => {
   const chromePath =
     configurations?.chromePath ||
-    process.env.CHROME_BIN ||
+    process.env.CHROME_PATH ||
     chromePaths.chrome ||
     chromePaths.chromium;
+
   console.log('executing chrome from', chromePath);
   const browser = await playwright['chromium'].launch({
     executablePath: chromePath,

--- a/docker-images/Dockerfile
+++ b/docker-images/Dockerfile
@@ -1,0 +1,11 @@
+
+FROM denoland/deno:debian-2.1.1
+RUN apt-get update && apt-get install -y curl
+
+# Install Google Chrome
+RUN curl -LO  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt-get install -y ./google-chrome-stable_current_amd64.deb
+RUN rm google-chrome-stable_current_amd64.deb
+RUN apt-get install -y chromium
+
+ENV CHROME_PATH=/usr/bin/google-chrome

--- a/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
@@ -14,7 +14,7 @@ impl Default for DenoRunnerOptions {
     fn default() -> Self {
         Self {
             context: ExecutionContext::default(),
-            deno_image_name: String::from("denoland/deno:alpine-2.0.6"),
+            deno_image_name: String::from("dcspark/shinkai-code-runner:0.8.0"),
             deno_binary_path: PathBuf::from(if cfg!(windows) {
                 "./shinkai-tools-runner-resources/deno.exe"
             } else {

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, path::PathBuf};
 
 use serde_json::Value;
 


### PR DESCRIPTION
Updates the code runner to use a custom Docker image (dcspark/shinkai-code-runner:0.8.0) that includes Google Chrome and  Deno. This allows Shinkai to run tools that required a web browser when use docker.