### PR TITLE
feat: added SHINKAI_NODE_LOCATION

### DIFF
--- a/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner_options.rs
@@ -3,11 +3,25 @@ use std::path::PathBuf;
 use super::execution_context::ExecutionContext;
 
 #[derive(Clone)]
+pub struct ShinkaiNodeLocation {
+    pub protocol: String,
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Clone)]
+pub enum RunnerType {
+    Host,
+    Docker,
+}
+
+#[derive(Clone)]
 pub struct DenoRunnerOptions {
     pub context: ExecutionContext,
     pub deno_binary_path: PathBuf,
     pub deno_image_name: String,
-    pub force_deno_in_host: bool,
+    pub force_runner_type: Option<RunnerType>,
+    pub shinkai_node_location: ShinkaiNodeLocation,
 }
 
 impl Default for DenoRunnerOptions {
@@ -20,9 +34,18 @@ impl Default for DenoRunnerOptions {
             } else {
                 "./shinkai-tools-runner-resources/deno"
             }),
-            force_deno_in_host: std::env::var("CI_FORCE_DENO_IN_HOST")
-                .map(|val| val == "true")
-                .unwrap_or(false),
+            force_runner_type: std::env::var("CI_FORCE_RUNNER_TYPE")
+                .map(|val| match val.as_str() {
+                    "host" => Some(RunnerType::Host),
+                    "docker" => Some(RunnerType::Docker),
+                    _ => None,
+                })
+                .unwrap_or(None),
+            shinkai_node_location: ShinkaiNodeLocation {
+                protocol: String::from("http"),
+                host: String::from("127.0.0.1"),
+                port: 9550,
+            },
         }
     }
 }


### PR DESCRIPTION
This PR introduces several enhancements to the Deno runner:

1. Added support for configuring the Shinkai Node location via the `ShinkaiNodeLocation` struct. This allows specifying the protocol, host, and port of the Shinkai Node.

2. Introduced the `RunnerType` enum to specify whether to run Deno in the host or Docker environment. The `force_deno_in_host` option has been replaced with `force_runner_type` to accommodate this change.

3. Updated the `run` method in `DenoRunner` to respect the `force_runner_type` option. If not specified, it falls back to the previous behavior of running in Docker if available, otherwise in the host.

4. Modified the Deno execution environment to pass the `SHINKAI_NODE_LOCATION` environment variable, allowing the running code to access the configured Shinkai Node location.

5. Added tests to verify the behavior of running with different Shinkai Node locations in both host and Docker environments.

These changes provide more flexibility in configuring the Deno runner and enable seamless integration with the Shinkai Node, regardless of the execution environment.
