### PR TITLE
- feature: execute from code files

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -67,6 +67,6 @@ jobs:
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
           EMBEDDING_API_URL : ${{ vars.EMBEDDING_API_URL }}
-          CI_FORCE_DENO_IN_HOST: true
+          CI_FORCE_RUNNER_TYPE: host
         run: |
           npx nx run-many -t test --parallel=false --skip-nx-cache

--- a/libs/shinkai-tools-runner/src/built_in_tools.test.rs
+++ b/libs/shinkai-tools-runner/src/built_in_tools.test.rs
@@ -1,6 +1,11 @@
+use std::collections::HashMap;
+
 use serde_json::Value;
 
-use crate::built_in_tools::{get_tool, get_tools};
+use crate::{
+    built_in_tools::{get_tool, get_tools},
+    tools::code_files::CodeFiles,
+};
 
 #[tokio::test]
 async fn get_tools_all_load() {
@@ -11,8 +16,11 @@ async fn get_tools_all_load() {
     let tools = get_tools();
     for (tool_name, tool_definition) in tools {
         println!("creating tool instance for {}", tool_name);
-        let tool_instance =
-            crate::tools::tool::Tool::new(tool_definition.code.unwrap(), Value::Null, None);
+        let code_files = CodeFiles {
+            files: HashMap::from([("main.ts".to_string(), tool_definition.code.unwrap())]),
+            entrypoint: "main.ts".to_string(),
+        };
+        let tool_instance = crate::tools::tool::Tool::new(code_files, Value::Null, None);
         println!("fetching definition for {}", tool_name);
         let defintion = tool_instance.definition().await;
         println!(

--- a/libs/shinkai-tools-runner/src/lib.test.rs
+++ b/libs/shinkai-tools-runner/src/lib.test.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
 
 use serde_json::json;
 
 use crate::built_in_tools::get_tool;
+use crate::tools::code_files::CodeFiles;
 use crate::tools::tool::Tool;
 
 #[tokio::test]
@@ -13,11 +15,11 @@ async fn shinkai_tool_echo() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-echo").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(None, serde_json::json!({ "message": "valparaíso" }), None)
         .await
@@ -32,8 +34,12 @@ async fn shinkai_tool_weather_by_city() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-weather-by-city").unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
+        code_files,
         serde_json::json!({ "apiKey": "63d35ff6068c3103ccd1227526935675" }),
         None,
     );
@@ -54,7 +60,11 @@ async fn shinkai_tool_inline() {
             return { message: `Hello, ${params.name}!` };
         }
 "#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(None, serde_json::json!({ "name": "world" }), None)
         .await
@@ -73,7 +83,11 @@ async fn shinkai_tool_inline_non_json_return() {
             return 5;
         }
 "#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool.run(None, serde_json::json!({}), None).await.unwrap();
     assert_eq!(run_result.data, 5);
 }
@@ -85,11 +99,11 @@ async fn shinkai_tool_web3_eth_balance() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-web3-eth-balance").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,
@@ -108,11 +122,11 @@ async fn shinkai_tool_web3_eth_uniswap() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-web3-eth-uniswap").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,
@@ -137,11 +151,11 @@ async fn shinkai_tool_download_page() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-download-pages").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,
@@ -177,7 +191,11 @@ async fn max_execution_time() {
             return { data: true };
         }
 "#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,
@@ -202,11 +220,14 @@ async fn shinkai_tool_download_page_stack_overflow() {
                 tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
             managed_runtime.block_on(async {
                 let tool_definition = get_tool("shinkai-tool-download-pages").unwrap();
-                let tool = Tool::new(
-                    tool_definition.code.clone().unwrap(),
-                    serde_json::Value::Null,
-                    None,
-                );
+                let code_files = CodeFiles {
+                    files: HashMap::from([(
+                        "main.ts".to_string(),
+                        tool_definition.code.clone().unwrap(),
+                    )]),
+                    entrypoint: "main.ts".to_string(),
+                };
+                let tool = Tool::new(code_files, serde_json::Value::Null, None);
                 tool.run(
                     None,
                     serde_json::json!({
@@ -231,11 +252,11 @@ async fn shinkai_tool_leiden() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-leiden").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let edges = vec![
         (2, 1, 1),
         (3, 1, 1),
@@ -339,11 +360,11 @@ async fn shinkai_tool_duckduckgo_search() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-duckduckgo-search").unwrap();
-    let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,
@@ -370,8 +391,12 @@ async fn shinkai_tool_playwright_example() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-playwright-example").unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
+        code_files,
         serde_json::json!({ "chromePath": std::env::var("CHROME_PATH").ok().unwrap_or("".to_string()) }),
         None,
     );
@@ -401,8 +426,12 @@ async fn shinkai_tool_defillama_lending_tvl_rankings() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-defillama-tvl-rankings").unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
+        code_files,
         serde_json::json!({ "chromePath": std::env::var("CHROME_PATH").ok().unwrap_or("".to_string()) }),
         None,
     );
@@ -421,7 +450,7 @@ async fn shinkai_tool_defillama_lending_tvl_rankings() {
     assert_eq!(run_result.unwrap().data["rowsCount"], 43);
 }
 
-// TODO: enable this test again when fix the tool
+// // TODO: enable this test again when fix the tool
 // #[tokio::test]
 // async fn shinkai_tool_aave_loan_requester() {
 //     let _ = env_logger::builder()
@@ -429,13 +458,18 @@ async fn shinkai_tool_defillama_lending_tvl_rankings() {
 //         .is_test(true)
 //         .try_init();
 //     let tool_definition = get_tool("shinkai-tool-aave-loan-requester").unwrap();
+//     let code_files = CodeFiles {
+//         files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+//         entrypoint: "main.ts".to_string(),
+//     };
 //     let tool = Tool::new(
-//         tool_definition.code.clone().unwrap(),
+//         code_files,
 //         serde_json::json!({ "chromePath": std::env::var("CHROME_PATH").ok().unwrap_or("".to_string()) }),
 //         None,
 //     );
 //     let run_result = tool
 //         .run(
+//             None,
 //             serde_json::json!({ "inputValue": "0.005", "assetSymbol": "ETH" }),
 //             None,
 //         )
@@ -459,7 +493,11 @@ async fn shinkai_tool_youtube_summary() {
         serde_json::json!({ "apiUrl": "http://127.0.0.1:11434", "lang": "en" })
     };
 
-    let tool = Tool::new(tool_definition.code.clone().unwrap(), configurations, None);
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, configurations, None);
     let run_result = tool
         .run(
             None,
@@ -481,14 +519,18 @@ async fn shinkai_tool_json_to_md() {
         .is_test(true)
         .try_init();
     let tool_definition = get_tool("shinkai-tool-json-to-md").unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), tool_definition.code.clone().unwrap())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        json!({
+        code_files,
+        serde_json::json!({
             "only_system": false
         }),
         None,
     );
-    let message = json!({
+    let message = serde_json::json!({
         "relevantSentencesFromText": [
             {
                 "citation_id": 5,

--- a/libs/shinkai-tools-runner/src/tools/code_files.rs
+++ b/libs/shinkai-tools-runner/src/tools/code_files.rs
@@ -1,0 +1,7 @@
+use std::collections::HashMap;
+
+#[derive(Default, Clone)]
+pub struct CodeFiles {
+    pub files: HashMap<String, String>,
+    pub entrypoint: String,
+}

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -3,72 +3,75 @@ use std::{
     path::{self, PathBuf},
 };
 
-use super::path_buf_ext::PathBufExt;
+use super::{code_files::CodeFiles, path_buf_ext::PathBufExt};
 use super::{execution_context::ExecutionContext, file_name_utils::sanitize_for_file_name};
 use nanoid::nanoid;
 
 #[derive(Default, Clone)]
 pub struct DenoExecutionStorage {
+    pub code_files: CodeFiles,
     pub context: ExecutionContext,
     pub code_id: String,
-    pub root: PathBuf,
-    pub root_code: PathBuf,
-    pub code: PathBuf,
-    pub code_entrypoint: PathBuf,
-    pub deno_cache: PathBuf,
-    pub logs: PathBuf,
-    pub log_file: PathBuf,
-    pub home: PathBuf,
-    pub assets: PathBuf,
-    pub mount: PathBuf,
+    pub root_folder_path: PathBuf,
+    pub root_code_folder_path: PathBuf,
+    pub code_folder_path: PathBuf,
+    pub code_entrypoint_file_path: PathBuf,
+    pub deno_cache_folder_path: PathBuf,
+    pub logs_folder_path: PathBuf,
+    pub log_file_path: PathBuf,
+    pub home_folder_path: PathBuf,
+    pub assets_folder_path: PathBuf,
+    pub mount_folder_path: PathBuf,
 }
 
 impl DenoExecutionStorage {
-    pub fn new(context: ExecutionContext) -> Self {
+    pub fn new(code: CodeFiles, context: ExecutionContext) -> Self {
         let code_id = format!("{}-{}", context.code_id, nanoid!());
-        let root = path::absolute(
+        let root_folder_path = path::absolute(
             context
                 .storage
                 .join(sanitize_for_file_name(context.context_id.clone()))
                 .clone(),
         )
         .unwrap();
-        let root_code = path::absolute(root.join("code")).unwrap();
-        let code = path::absolute(root_code.join(code_id.clone())).unwrap();
-        let logs = path::absolute(root.join("logs")).unwrap();
-        let log_file = path::absolute(logs.join(format!(
+        let root_code_folder_path = path::absolute(root_folder_path.join("code")).unwrap();
+        let code_folder_path = path::absolute(root_code_folder_path.join(code_id.clone())).unwrap();
+        let logs_folder_path = path::absolute(root_folder_path.join("logs")).unwrap();
+        let log_file_path = path::absolute(logs_folder_path.join(format!(
             "log_{}_{}.log",
             sanitize_for_file_name(context.context_id.clone()),
             sanitize_for_file_name(context.execution_id.clone())
         )))
         .unwrap();
-        let deno_cache = path::absolute(root.join("deno-cache")).unwrap();
+        let deno_cache_folder_path = path::absolute(root_folder_path.join("deno-cache")).unwrap();
+        let code_entrypoint_file_path = code_folder_path.join(&code.entrypoint);
         Self {
+            code_files: code,
             context,
+            code_folder_path,
             code_id: code_id.clone(),
-            root: root.clone(),
-            root_code,
-            code: code.clone(),
-            code_entrypoint: code.join("index.ts"),
-            deno_cache,
-            logs: logs.clone(),
-            log_file,
-            home: root.join("home"),
-            assets: root.join("assets"),
-            mount: root.join("mount"),
+            root_folder_path: root_folder_path.clone(),
+            root_code_folder_path,
+            code_entrypoint_file_path,
+            deno_cache_folder_path,
+            logs_folder_path: logs_folder_path.clone(),
+            log_file_path,
+            home_folder_path: root_folder_path.join("home"),
+            assets_folder_path: root_folder_path.join("assets"),
+            mount_folder_path: root_folder_path.join("mount"),
         }
     }
 
-    pub fn init(&self, code: &str, pristine_cache: Option<bool>) -> anyhow::Result<()> {
+    pub fn init(&self, pristine_cache: Option<bool>) -> anyhow::Result<()> {
         for dir in [
-            &self.root,
-            &self.root_code,
-            &self.code,
-            &self.deno_cache,
-            &self.logs,
-            &self.home,
-            &self.assets,
-            &self.mount,
+            &self.root_folder_path,
+            &self.root_code_folder_path,
+            &self.code_folder_path,
+            &self.deno_cache_folder_path,
+            &self.logs_folder_path,
+            &self.home_folder_path,
+            &self.assets_folder_path,
+            &self.mount_folder_path,
         ] {
             log::info!("creating directory: {}", dir.display());
             std::fs::create_dir_all(dir).map_err(|e| {
@@ -77,29 +80,47 @@ impl DenoExecutionStorage {
             })?;
         }
 
-        log::info!("creating code file: {}", self.code_entrypoint.display());
-        std::fs::write(&self.code_entrypoint, code).map_err(|e| {
-            log::error!("failed to write code to index.ts: {}", e);
-            e
-        })?;
+        log::info!(
+            "creating project files, entrypoint: {}",
+            self.code_files.entrypoint
+        );
+
+        for (path, content) in self.code_files.files.iter() {
+            let file_path = self.code_folder_path.join(path);
+            log::info!("writing file: {}", file_path.display());
+            if let Some(parent) = file_path.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    log::error!(
+                        "failed to create parent directory {}: {}",
+                        parent.display(),
+                        e
+                    );
+                    e
+                })?;
+            }
+            std::fs::write(&file_path, content).map_err(|e| {
+                log::error!("failed to write file {}: {}", file_path.display(), e);
+                e
+            })?;
+        }
 
         log::info!(
             "creating log file if not exists: {}",
-            self.log_file.display()
+            self.log_file_path.display()
         );
-        if !self.log_file.exists() {
-            std::fs::write(&self.log_file, "").map_err(|e| {
+        if !self.log_file_path.exists() {
+            std::fs::write(&self.log_file_path, "").map_err(|e| {
                 log::error!("failed to create log file: {}", e);
                 e
             })?;
         }
 
         if pristine_cache.unwrap_or(false) {
-            std::fs::remove_dir_all(&self.deno_cache)?;
-            std::fs::create_dir(&self.deno_cache)?;
+            std::fs::remove_dir_all(&self.deno_cache_folder_path)?;
+            std::fs::create_dir(&self.deno_cache_folder_path)?;
             log::info!(
                 "cleared deno cache directory: {}",
-                self.deno_cache.display()
+                self.deno_cache_folder_path.display()
             );
         }
 
@@ -115,7 +136,7 @@ impl DenoExecutionStorage {
         let mut file = std::fs::OpenOptions::new()
             .append(true)
             .create(true) // Create the file if it doesn't exist
-            .open(self.log_file.clone())
+            .open(self.log_file_path.clone())
             .map_err(|e| {
                 log::error!("failed to open log file: {}", e);
                 e
@@ -125,25 +146,28 @@ impl DenoExecutionStorage {
     }
 
     pub fn relative_to_root(&self, path: PathBuf) -> String {
-        let path = path.strip_prefix(&self.root).unwrap();
+        let path = path.strip_prefix(&self.root_folder_path).unwrap();
         path.to_path_buf().as_normalized_string()
     }
 }
 
 // We do best effort to remove ephemereal folders
-impl Drop for DenoExecutionStorage {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_dir_all(&self.code) {
-            log::warn!(
-                "failed to remove code directory {}: {}",
-                self.code.display(),
-                e
-            );
-        } else {
-            log::info!("removed code directory: {}", self.code.display());
-        }
-    }
-}
+// impl Drop for DenoExecutionStorage {
+//     fn drop(&mut self) {
+//         if let Err(e) = std::fs::remove_dir_all(&self.code_folder_path) {
+//             log::warn!(
+//                 "failed to remove code directory {}: {}",
+//                 self.code_folder_path.display(),
+//                 e
+//             );
+//         } else {
+//             log::info!(
+//                 "removed code directory: {}",
+//                 self.code_folder_path.display()
+//             );
+//         }
+//     }
+// }
 
 #[cfg(test)]
 #[path = "deno_execution_storage.test.rs"]

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -152,22 +152,22 @@ impl DenoExecutionStorage {
 }
 
 // We do best effort to remove ephemereal folders
-// impl Drop for DenoExecutionStorage {
-//     fn drop(&mut self) {
-//         if let Err(e) = std::fs::remove_dir_all(&self.code_folder_path) {
-//             log::warn!(
-//                 "failed to remove code directory {}: {}",
-//                 self.code_folder_path.display(),
-//                 e
-//             );
-//         } else {
-//             log::info!(
-//                 "removed code directory: {}",
-//                 self.code_folder_path.display()
-//             );
-//         }
-//     }
-// }
+impl Drop for DenoExecutionStorage {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_dir_all(&self.code_folder_path) {
+            log::warn!(
+                "failed to remove code directory {}: {}",
+                self.code_folder_path.display(),
+                e
+            );
+        } else {
+            log::info!(
+                "removed code directory: {}",
+                self.code_folder_path.display()
+            );
+        }
+    }
+}
 
 #[cfg(test)]
 #[path = "deno_execution_storage.test.rs"]

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.test.rs
@@ -1,5 +1,8 @@
+use std::collections::HashMap;
+
 use crate::tools::{
-    deno_execution_storage::DenoExecutionStorage, execution_context::ExecutionContext,
+    code_files::CodeFiles, deno_execution_storage::DenoExecutionStorage,
+    execution_context::ExecutionContext,
 };
 
 #[tokio::test]
@@ -10,23 +13,36 @@ async fn test_execution_storage_init() {
         .try_init();
 
     let test_dir = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
-    let storage = DenoExecutionStorage::new(ExecutionContext {
-        storage: test_dir.clone(),
-        ..Default::default()
-    });
 
     let test_code = "console.log('test');";
-    storage.init(test_code, None).unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), test_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    let storage = DenoExecutionStorage::new(
+        code_files,
+        ExecutionContext {
+            storage: test_dir.clone(),
+            ..Default::default()
+        },
+    );
+
+    storage.init(None).unwrap();
 
     // Verify directories were created
-    assert!(storage.root.exists());
-    assert!(storage.code.exists());
-    assert!(storage.deno_cache.exists());
-    assert!(storage.logs.exists());
-    assert!(storage.home.exists());
+    assert!(storage.root_folder_path.exists());
+    assert!(storage.code_folder_path.exists());
+    assert!(storage.deno_cache_folder_path.exists());
+    assert!(storage.logs_folder_path.exists());
+    assert!(storage.home_folder_path.exists());
+    assert!(storage.mount_folder_path.exists());
+    assert!(storage.assets_folder_path.exists());
+    assert!(storage.code_entrypoint_file_path.exists());
+    assert!(storage.code_entrypoint_file_path.file_name().unwrap() == "main.ts");
 
     // Verify code file was written correctly
-    let code_contents = std::fs::read_to_string(storage.code_entrypoint.clone()).unwrap();
+    let code_contents = std::fs::read_to_string(storage.code_entrypoint_file_path.clone()).unwrap();
     assert_eq!(code_contents, test_code);
 }
 
@@ -38,25 +54,37 @@ async fn test_execution_storage_clean_cache() {
         .try_init();
 
     let test_dir = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
-    let storage = DenoExecutionStorage::new(ExecutionContext {
-        storage: test_dir.clone(),
-        ..Default::default()
-    });
 
     // Initialize with some test code
     let test_code = "console.log('test');";
-    storage.init(test_code, None).unwrap();
+
+    let storage = DenoExecutionStorage::new(
+        CodeFiles {
+            files: HashMap::from([("main.ts".to_string(), test_code.to_string())]),
+            entrypoint: "main.ts".to_string(),
+        },
+        ExecutionContext {
+            storage: test_dir.clone(),
+            ..Default::default()
+        },
+    );
+    storage.init(None).unwrap();
 
     // Create a test file in the cache directory
-    let test_cache_file = storage.deno_cache.join("test_cache.txt");
+    let test_cache_file = storage.deno_cache_folder_path.join("test_cache.txt");
     std::fs::write(&test_cache_file, "test cache content").unwrap();
     assert!(test_cache_file.exists());
 
     // Reinitialize with pristine cache enabled
-    storage.init(test_code, Some(true)).unwrap();
+    storage.init(Some(true)).unwrap();
 
     // Verify cache directory was cleared
     assert!(!test_cache_file.exists());
-    assert!(storage.deno_cache.exists()); // Directory should still exist but be empty
-    assert!(std::fs::read_dir(&storage.deno_cache).unwrap().count() == 0);
+    assert!(storage.deno_cache_folder_path.exists()); // Directory should still exist but be empty
+    assert!(
+        std::fs::read_dir(&storage.deno_cache_folder_path)
+            .unwrap()
+            .count()
+            == 0
+    );
 }

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
@@ -1,4 +1,5 @@
 use crate::tools::{
+    code_files::CodeFiles,
     deno_execution_storage::DenoExecutionStorage,
     deno_runner::DenoRunner,
     deno_runner_options::{DenoRunnerOptions, RunnerType, ShinkaiNodeLocation},
@@ -18,8 +19,12 @@ async fn test_run_echo_tool() {
       console.log('{"message":"hello world"}');
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let result = deno_runner
-        .run(code, None, None)
+        .run(code_files, None, None)
         .await
         .map_err(|e| {
             log::error!("Failed to run deno code: {}", e);
@@ -42,9 +47,13 @@ async fn test_run_with_env() {
       console.log(process.env.HELLO_WORLD);
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let mut envs = HashMap::<String, String>::new();
     envs.insert("HELLO_WORLD".to_string(), "hello world!".to_string()); // Insert the key-value pair
-    let result = deno_runner.run(code, Some(envs), None).await.unwrap();
+    let result = deno_runner.run(code_files, Some(envs), None).await.unwrap();
 
     assert_eq!(result.first().unwrap(), "hello world!");
 }
@@ -71,7 +80,13 @@ async fn test_write_forbidden_folder() {
         throw e;
       }
     "#;
-    let result = deno_runner.run(code, None, None).await.map_err(|e| {
+
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    let result = deno_runner.run(code_files, None, None).await.map_err(|e| {
         log::error!("Failed to run deno code: {}", e);
         e
     });
@@ -91,7 +106,10 @@ async fn test_execution_storage_cache_contains_files() {
         import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
         console.log('test');
     "#;
-
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), test_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
     let context_id = String::from("test-execution-cache");
     // Run the code to ensure dependencies are downloaded
     let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
@@ -102,17 +120,25 @@ async fn test_execution_storage_cache_contains_files() {
         },
         ..Default::default()
     });
-    let _ = deno_runner.run(test_code, None, None).await.unwrap();
+
+    let _ = deno_runner.run(code_files, None, None).await.unwrap();
 
     // Verify cache directory contains files
-    let storage = DenoExecutionStorage::new(ExecutionContext {
-        storage: test_dir.clone(),
-        context_id,
-        ..Default::default()
-    });
+    let empty_code_files = CodeFiles {
+        files: HashMap::new(),
+        entrypoint: String::new(),
+    };
+    let storage = DenoExecutionStorage::new(
+        empty_code_files,
+        ExecutionContext {
+            storage: test_dir.clone(),
+            context_id,
+            ..Default::default()
+        },
+    );
 
-    assert!(storage.deno_cache.exists());
-    let cache_files = std::fs::read_dir(&storage.deno_cache).unwrap();
+    assert!(storage.deno_cache_folder_path.exists());
+    let cache_files = std::fs::read_dir(&storage.deno_cache_folder_path).unwrap();
     assert!(cache_files.count() > 0);
 }
 
@@ -136,7 +162,12 @@ async fn test_run_with_shinkai_node_location_host() {
       console.log(process.env.SHINKAI_NODE_LOCATION);
     "#;
 
-    let result = deno_runner.run(code, None, None).await.unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    let result = deno_runner.run(code_files, None, None).await.unwrap();
     assert_eq!(result.first().unwrap(), "https://127.0.0.2:9554");
 }
 
@@ -160,6 +191,79 @@ async fn test_run_with_shinkai_node_location_docker() {
       console.log(process.env.SHINKAI_NODE_LOCATION);
     "#;
 
-    let result = deno_runner.run(code, None, None).await.unwrap();
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let result = deno_runner.run(code_files, None, None).await.unwrap();
     assert_eq!(result.first().unwrap(), "https://host.docker.internal:9554");
+}
+
+#[tokio::test]
+async fn test_run_with_file_sub_path() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        shinkai_node_location: ShinkaiNodeLocation {
+            protocol: String::from("https"),
+            host: String::from("127.0.0.2"),
+            port: 9554,
+        },
+        force_runner_type: Some(RunnerType::Docker),
+        ..Default::default()
+    });
+    let code = r#"
+      console.log("hello world");
+    "#;
+
+    let code_files = CodeFiles {
+        files: HashMap::from([("potato_a/potato_b/main.ts".to_string(), code.to_string())]),
+        entrypoint: "potato_a/potato_b/main.ts".to_string(),
+    };
+    let result = deno_runner.run(code_files, None, None).await.unwrap();
+    assert_eq!(result.first().unwrap(), "hello world");
+}
+
+#[tokio::test]
+async fn test_run_with_imports() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        shinkai_node_location: ShinkaiNodeLocation {
+            protocol: String::from("https"),
+            host: String::from("127.0.0.2"),
+            port: 9554,
+        },
+        force_runner_type: Some(RunnerType::Docker),
+        ..Default::default()
+    });
+
+    let code_files = CodeFiles {
+        files: HashMap::from([
+            (
+                "potato_a/potato_b/main.ts".to_string(),
+                r#"
+                    import { hello } from "../../lorem/ipsum/dolor/importum.ts";
+                    console.log(hello);
+            "#
+                .to_string(),
+            ),
+            (
+                "lorem/ipsum/dolor/importum.ts".to_string(),
+                r#"
+                    export const hello = 'hello world';
+                "#
+                .to_string(),
+            ),
+        ]),
+        entrypoint: "potato_a/potato_b/main.ts".to_string(),
+    };
+    let result = deno_runner.run(code_files, None, None).await.unwrap();
+    assert_eq!(result.first().unwrap(), "hello world");
 }

--- a/libs/shinkai-tools-runner/src/tools/mod.rs
+++ b/libs/shinkai-tools-runner/src/tools/mod.rs
@@ -7,5 +7,6 @@ pub mod execution_error;
 pub mod run_result;
 pub mod tool;
 pub mod tool_definition;
+pub mod code_files;
 mod path_buf_ext;
 mod file_name_utils;

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -3,7 +3,8 @@ use std::{collections::HashMap, path::PathBuf};
 use serde_json::Value;
 
 use crate::tools::{
-    deno_runner_options::DenoRunnerOptions, execution_context::ExecutionContext, tool::Tool,
+    code_files::CodeFiles, deno_runner_options::DenoRunnerOptions,
+    execution_context::ExecutionContext, tool::Tool,
 };
 
 #[tokio::test]
@@ -14,9 +15,15 @@ async fn get_tool_definition() {
         "/../../apps/shinkai-tool-echo/src/index.ts"
     ))
     .to_string();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let configurations = serde_json::json!({});
 
-    let tool = Tool::new(code, configurations, None);
+    let tool = Tool::new(code_files, configurations, None);
 
     let definition = tool.definition().await.unwrap();
 
@@ -31,9 +38,15 @@ async fn run_tool() {
         "/../../apps/shinkai-tool-echo/src/index.ts"
     ))
     .to_string();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let configurations = Value::Null;
 
-    let tool = Tool::new(code, configurations, None);
+    let tool = Tool::new(code_files, configurations, None);
 
     let result = tool
         .run(
@@ -63,7 +76,13 @@ async fn shinkai_tool_with_env() {
             return { foo: process.env.BAR };
         }
 "#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
+
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let mut envs = HashMap::<String, String>::new();
     envs.insert("BAR".to_string(), "bar".to_string());
     let run_result = tool
@@ -92,6 +111,12 @@ async fn shinkai_tool_run_concurrency() {
             return result;
         }
     "#;
+
+    let code_files1 = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code1.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let js_code2 = r#"
         import _ from 'npm:lodash';
         function run(configurations, params) {
@@ -100,6 +125,11 @@ async fn shinkai_tool_run_concurrency() {
             };
         }
     "#;
+
+    let code_files2 = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code2.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
 
     let js_code3 = r#"
         import { sum } from 'npm:mathjs';
@@ -110,11 +140,16 @@ async fn shinkai_tool_run_concurrency() {
         }
     "#;
 
+    let code_files3 = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code3.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let execution_storage = "./shinkai-tools-runner-execution-storage";
     let context_id = String::from("context-patata");
     let execution_id = String::from("2");
     let tool1 = Tool::new(
-        js_code1.to_string(),
+        code_files1,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -128,7 +163,7 @@ async fn shinkai_tool_run_concurrency() {
         }),
     );
     let tool2 = Tool::new(
-        js_code2.to_string(),
+        code_files2,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -142,7 +177,7 @@ async fn shinkai_tool_run_concurrency() {
         }),
     );
     let tool3 = Tool::new(
-        js_code3.to_string(),
+        code_files3,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -186,12 +221,17 @@ async fn test_file_persistence_in_home() {
         }
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let execution_storage = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("shinkai-tools-runner-execution-storage");
     let context_id = "test-context-id".to_string();
 
     let tool = Tool::new(
-        js_code.to_string(),
+        code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -241,8 +281,13 @@ async fn test_mount_file_in_mount() {
         }
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let tool = Tool::new(
-        js_code.to_string(),
+        code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -288,8 +333,13 @@ async fn test_mount_and_edit_file_in_mount() {
         }
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let tool = Tool::new(
-        js_code.to_string(),
+        code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -339,8 +389,13 @@ async fn test_mount_file_in_assets() {
         }
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let tool = Tool::new(
-        js_code.to_string(),
+        code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -386,9 +441,14 @@ async fn test_fail_when_try_write_assets() {
         }
     "#;
 
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
     let context_id = format!("test-mount-file-in-assets-{}", nanoid::nanoid!());
     let tool = Tool::new(
-        js_code.to_string(),
+        code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
@@ -431,8 +491,12 @@ async fn shinkai_tool_param_with_quotes() {
                 escaped: params.escaped
             };
         }
-"#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
+    "#;
+    let code_files = CodeFiles {
+        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+    let tool = Tool::new(code_files, serde_json::Value::Null, None);
     let run_result = tool
         .run(
             None,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shinkai_protocol/source",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shinkai_protocol/source",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@coinbase/coinbase-sdk": "^0.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai_protocol/source",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "This repository serves as the ecosystem to execute Shinkai tools, provided by the Shinkai team or third-party developers, in a secure environment. It provides a sandboxed space for executing these tools, ensuring that they run safely and efficiently, while also allowing for seamless integration with Rust code.",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
## Refactor code from string with CodeFiles struct

1. Added a new `CodeFiles` struct to represent the code files for a tool, including a map of file paths to contents and an entrypoint file path. This replaces passing around a single code string.

2. Updated the `DenoExecutionStorage` struct to take a `CodeFiles` instead of a code string in its constructor. It now writes out all the files in `CodeFiles` when initializing the storage directories.

3. Updated the `DenoRunner` to take a `CodeFiles` instead of a code string when running. It passes this through to the `DenoExecutionStorage`.

4. Updated tests to construct `CodeFiles` structs instead of passing code strings directly. For example:


**Example**

```rust
    let main_code = r#"
        import { helper } from "./helper.ts";
        import { data } from "./data.ts";
        
        function run() {
            return helper(data);
        }
    "#;

    let helper_code = r#"
        export function helper(input: string) {
            return `processed ${input}`;
        }
    "#;

    let data_code = r#"
        export const data = "test data";
    "#;

    let code_files = CodeFiles {
        files: HashMap::from([
            ("main.ts".to_string(), main_code.to_string()),
            ("helper.ts".to_string(), helper_code.to_string()),
            ("data.ts".to_string(), data_code.to_string()),
        ]),
        entrypoint: "main.ts".to_string(),
    };

    let tool = Tool::new(code_files, Value::Null, None);
    let result = tool.run(None, Value::Null, None).await;
    
    assert!(result.is_ok());
    assert_eq!(result.unwrap().data, "processed test data");
```

