### PR TITLE
- feature: mount in host runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,25 @@
 
 [![Mutable.ai Auto Wiki](https://img.shields.io/badge/Auto_Wiki-Mutable.ai-blue)](https://wiki.mutable.ai/dcSpark/shinkai-tools)
 
-Shinkai Tools serves as the ecosystem to execute Shinkai tools, provided by the Shinkai team or third-party developers, in a secure environment. It provides a sandboxed space for executing these tools, 
+Shinkai Tools serves as the ecosystem to execute Shinkai tools, provided by the Shinkai team or third-party developers, in a secure environment. It provides a sandboxed space for executing these tools,
 ensuring that they run safely and efficiently, while also allowing for seamless integration with Rust code.
 
 This repository is a comprehensive collection of tools and utilities designed to facilitate the integration of JavaScript and Rust code. It provides a framework for executing Deno scripts within a Rust environment, allowing for seamless communication and data exchange between the two languages.
 
 The primary components of this repository include:
 
-* `apps/shinkai-tool-*` These are small Deno tools designed to perform specific tasks. Each tool is a self-contained project with its own configuration and build process, allowing for easy maintenance and updates.
-* `libs/shinkai-tools-builder` type definitions to make tools more readable and easy to code.
-* `libs/shinkai-tools-runner` is a Rust library used to execute a tool in a secured and performant Deno environment, providing a safe and efficient way to run tools within the Shinkai ecosystem.
+- `apps/shinkai-tool-*` These are small Deno tools designed to perform specific tasks. Each tool is a self-contained project with its own configuration and build process, allowing for easy maintenance and updates.
+- `libs/shinkai-tools-builder` type definitions to make tools more readable and easy to code.
+- `libs/shinkai-tools-runner` is a Rust library used to execute a tool in a secured and performant Deno environment, providing a safe and efficient way to run tools within the Shinkai ecosystem.
 
 ## Documentation
-
-General Documentation: [https://docs.shinkai.com](https://docs.shinkai.com)
 
 More In Depth Codebase Documentation (Mutable.ai): [https://wiki.mutable.ai/dcSpark/shinkai-tools](https://wiki.mutable.ai/dcSpark/shinkai-tools)
 
 ## Getting started
 
 ### Init Typescript side
+
 ```
 # In windows admin privileges is required because rquickjs-sys uses a git patch
 npm ci
@@ -30,53 +29,81 @@ npx nx run-many -t build
 npx nx run-many -t test
 ```
 
-## How to use a tool from Rust side (using shinkai_tools_runner)
+#### Example Usage
 
-To execute a tool from the Rust side, you can follow these steps:
+To call a tool from the Rust side, you can use the following example:
 
-1. First, ensure that the tool's JavaScript file is located in the correct directory as specified in the `Cargo.toml` file.
-2. In your Rust code, import the necessary modules and create a new instance of the `Tool` struct.
-3. Load the tool's JavaScript file using the `load` method, passing the path to the file as an argument.
-4. Once the tool is loaded, you can call its functions using the `run` method, passing any required arguments as JSON strings.
-
-Here's an example:
 ```rust
-use shinkai_tools_runner::built_in_tools::get_tool;
-use shinkai_tools_runner::tools::tool::Tool;
+use shinkai_tools_runner::{Tool, CodeFiles};
+use serde_json::json;
 
 #[tokio::main]
 async fn main() {
-    let tool_definition = get_tool("shinkai-tool-echo").unwrap();
+    // Define the inline tool's Deno code
+    let js_code = r#"
+        function run(configurations, params) {
+            console.log("Environment variable:", Deno.env.get('MOUNT')); // rw files /path/to/mount1,/path/to/mount2
+            console.log("Environment variable:", Deno.env.get('ASSETS')); // ro files /path/to/asset1,/path/to/asset2
+            console.log("Environment variable:", Deno.env.get('HOME')); // rw files /path/to/home
+            console.log("Environment variable:", Deno.env.get('SHINKAI_NODE_LOCATION')); // https://host.docker.internal:9554 (if it's running in docker) or 127.0.0.2:9554 (if it's running in host)
+            return { message: `Echoing: ${params.message}` };
+        }
+    "#;
+
+    // Set up the code files for the tool
+    // It's important to note that the entrypoint must be the name of the file in the `files` map.
+    // In this case, the entrypoint is `main.ts` and it's mapped to the `js_code` variable.
+    // You can also include other files in the `files` map if your tool needs them.
+    let code_files = CodeFiles {
+        files: std::collections::HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    // Create a random file to be used as a mount point. Basically it's a file that could be read/write by the tool
+    let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    std::fs::create_dir_all(test_file_path.parent().unwrap()).unwrap();
+    println!("test file path: {:?}", test_file_path);
+    std::fs::write(&test_file_path, "1").unwrap();
+
+    // Create the tool instance
     let tool = Tool::new(
-        tool_definition.code.clone().unwrap(),
-        serde_json::Value::Null,
-        None,
-    );
-    let run_result = tool
-        .run(serde_json::json!({ "message": "valparaíso" }), None)
-        .await
-        .unwrap();
-    println!("{}", run_result.data["message"]);
-    // > "Hello, world!"
+        code_files,
+        json!({}),
+        Some(DenoRunnerOptions {
+            context: ExecutionContext {
+                // Here you specify where the system will store all the files related to execute code
+                storage: execution_storage.into(),
+                // Here you specify the context id, which is a unique identifier for the execution context.
+                // Tools in the same context share the same storage.
+                // It creates a folder with the context id and all the files related to the execution are stored in it.
+                context_id: context_id.clone(),
+                // The execution id is a unique identifier for the execution of the tool
+                // It creates logs for every execution and stores them in the storage folder.
+                execution_id: execution_id.clone(),
+                // The code id is a unique identifier for the code being executed.
+                // Used to identify the tools that's logging in the same execution.
+                code_id: "js_code1".into(),
+                // Here you specify the files that will be mounted with read/write permissions into the Deno execution environment.
+                mount_files: vec![test_file_path.to_path_buf().clone()],
+
+                // Here you specify the files that will be mounted with read-only permissions into the Deno execution environment.
+                // assets_files: vec![test_file_path.to_path_buf().clone()],
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+    // Run the tool with input data
+    let result = tool.run(None, json!({"message": "Hello, Shinkai!"}), None).await.unwrap();
+
+    // Print the output
+    println!("Tool output: {:?}", result.data["message"]); // Echoing: ${params.message}
+
+    // After the execution you can find logs in the storage folder, specifically in storage/{context_id}/logs/{execution_id}_....log
 }
 ```
 
-Also you can run inline tools. The only needed structure is a run method (it can be sync or async) with two parameters:
-
-```rust
-    let js_code = r#"
-        function run(configurations, params) {
-            return { message: `Hello, ${params.name}!` };
-        }
-"#;
-    let tool = Tool::new(js_code.to_string(), serde_json::Value::Null, None);
-    let run_result = tool
-        .run(serde_json::json!({ "name": "world" }), None)
-        .await
-        .unwrap();
-    println!("{}", run_result.data["message"]);
-    // > "Hello, world!"
-```
+This example demonstrates how to set up and call a Shinkai tool from Rust, including how to pass input data and handle the output.
 
 ## Adding a New Shinkai Tool
 

--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -103,6 +103,12 @@ impl DenoExecutionStorage {
                 e
             })?;
         }
+        log::info!("creating deno.json file");
+        let deno_json_path = self.code_folder_path.join("deno.json");
+        std::fs::write(&deno_json_path, "{}").map_err(|e| {
+            log::error!("failed to write deno.json file: {}", e);
+            e
+        })?;
 
         log::info!(
             "creating log file if not exists: {}",

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.rs
@@ -503,12 +503,17 @@ impl DenoRunner {
             format!("--allow-read={}", exec_path.to_string()),
             "--allow-write=/var/folders".to_string(),
             "--allow-read=/var/folders".to_string(),
+            "--allow-read=C:\\Users\\agall\\AppData\\Local\\Temp".to_string(),
+            "--allow-write=C:\\Users\\agall\\AppData\\Local\\Temp".to_string(),
             "--allow-read=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
             "--allow-read=/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary".to_string(),
             "--allow-read=/Applications/Chromium.app/Contents/MacOS/Chromium".to_string(),
             "--allow-read=C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe".to_string(),
             "--allow-read=C:\\Program Files (x86)\\Google\\Chrome SxS\\Application\\chrome.exe".to_string(),
             "--allow-read=C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe".to_string(),
+            "--allow-read=C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe".to_string(),
+            "--allow-read=C:\\Program Files\\Google\\Chrome SxS\\Application\\chrome.exe".to_string(),
+            "--allow-read=C:\\Program Files\\Chromium\\Application\\chrome.exe".to_string(),
             "--allow-read=/usr/bin/chromium".to_string(),
         ];
 

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.rs
@@ -127,7 +127,7 @@ impl DenoRunner {
             mount_params.extend([String::from("--mount"), mount_param]);
         }
         // Mount each asset file to /app/assets
-        for file in &self.options.context.assets {
+        for file in &self.options.context.assets_files {
             let mount_param = format!(
                 r#"type=bind,readonly=true,source={},target=/app/{}/{}"#,
                 path::absolute(file).unwrap().as_normalized_string(),
@@ -312,7 +312,7 @@ impl DenoRunner {
         ];
 
         for file in &self.options.context.mount_files {
-            let dest_path = execution_storage.mount.join(file.file_name().unwrap());
+            let dest_path = execution_storage.mount_folder_path.join(file.file_name().unwrap());
             std::fs::copy(file, &dest_path)?;
             let mount_param = format!(
                 r#"--allow-read={},--allow-write={}"#,
@@ -344,9 +344,9 @@ impl DenoRunner {
             ),
         );
 
-        command.env("HOME", execution_storage.home.clone());
-        command.env("ASSETS", execution_storage.assets.clone());
-        command.env("MOUNT", execution_storage.mount.clone());
+        command.env("HOME", execution_storage.home_folder_path.clone());
+        command.env("ASSETS", execution_storage.assets_folder_path.clone());
+        command.env("MOUNT", execution_storage.mount_folder_path.clone());
 
         if let Some(envs) = envs {
             command.envs(envs);

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.rs
@@ -190,7 +190,7 @@ impl DenoRunner {
         }
 
         let deno_permissions = self.get_deno_permissions(
-            "/deno",
+            "/usr/bin/deno",
             "/app/home",
             &self
                 .options

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
@@ -212,7 +212,6 @@ async fn test_run_with_file_sub_path() {
             host: String::from("127.0.0.2"),
             port: 9554,
         },
-        force_runner_type: Some(RunnerType::Docker),
         ..Default::default()
     });
     let code = r#"
@@ -240,7 +239,6 @@ async fn test_run_with_imports() {
             host: String::from("127.0.0.2"),
             port: 9554,
         },
-        force_runner_type: Some(RunnerType::Docker),
         ..Default::default()
     });
 

--- a/libs/shinkai-tools-runner/src/tools/execution_context.rs
+++ b/libs/shinkai-tools-runner/src/tools/execution_context.rs
@@ -6,7 +6,7 @@ pub struct ExecutionContext {
     pub execution_id: String,
     pub code_id: String,
     pub storage: PathBuf,
-    pub assets: Vec<PathBuf>,
+    pub assets_files: Vec<PathBuf>,
     pub mount_files: Vec<PathBuf>,
 }
 
@@ -17,7 +17,7 @@ impl Default for ExecutionContext {
             execution_id: nanoid::nanoid!(),
             code_id: nanoid::nanoid!(),
             storage: PathBuf::from("./shinkai-tools-runner-execution-storage"),
-            assets: Vec::new(),
+            assets_files: Vec::new(),
             mount_files: Vec::new(),
         }
     }

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -180,7 +180,7 @@ async fn test_file_persistence_in_home() {
             for await (const entry of Deno.readDir("./")) {
                 console.log(entry.name);
             }
-            await Deno.writeTextFile("./home/test.txt", content);
+            await Deno.writeTextFile(`${process.env.HOME}/test.txt`, content);
             const data = { success: true };
             return data;
         }
@@ -231,11 +231,11 @@ async fn test_mount_file_in_mount() {
     let js_code = r#"
         async function run (c, p) {
             const files = [];
-            for await (const dirEntry of Deno.readDir("./mount")) {
+            for await (const dirEntry of Deno.readDir(`${process.env.HOME}/mount`)) {
                 files.push(dirEntry.name);
             }
             console.log("files in mount:", files);
-            const content = await Deno.readTextFile(`./mount/${process.env.FILE_NAME}`);
+            const content = await Deno.readTextFile(`${process.env.HOME}/mount/${process.env.FILE_NAME}`);
             console.log(content);
             return content;
         }
@@ -381,7 +381,7 @@ async fn test_fail_when_try_write_assets() {
 
     let js_code = r#"
         async function run (c, p) {
-            await Deno.writeTextFile(`./assets/${process.env.FILE_NAME}`);
+            await Deno.writeTextFile(`${process.env.ASSETS}/${process.env.FILE_NAME}`);
             return;
         }
     "#;

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -400,7 +400,7 @@ async fn test_mount_file_in_assets() {
         Some(DenoRunnerOptions {
             context: ExecutionContext {
                 storage: execution_storage.clone(),
-                assets: vec![test_file_path.to_path_buf().clone()],
+                assets_files: vec![test_file_path.to_path_buf().clone()],
                 ..Default::default()
             },
             ..Default::default()
@@ -455,7 +455,7 @@ async fn test_fail_when_try_write_assets() {
                 storage: execution_storage.clone(),
                 context_id: context_id.clone(),
                 code_id: "js_code".into(),
-                assets: vec![test_file_path.to_path_buf().clone()],
+                assets_files: vec![test_file_path.to_path_buf().clone()],
                 ..Default::default()
             },
             ..Default::default()

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -423,7 +423,7 @@ async fn test_fail_when_try_write_assets() {
         .is_test(true)
         .try_init();
 
-    let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let test_file_path = tempfile::NamedTempFile::new_in("./shinkai-tools-runner-execution-storage").unwrap().into_temp_path();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
 
@@ -434,8 +434,8 @@ async fn test_fail_when_try_write_assets() {
             "main.ts".to_string(),
             r#"
                 async function run (c, p) {
-                    console.log('assetcitos', Deno.env.get("ASSETS"));
                     const assets = Deno.env.get("ASSETS").split(',');
+                    console.log('writing', assets[0]);
                     await Deno.writeTextFile(assets[0], "2");
                     return;
                 }

--- a/libs/shinkai-tools-runner/src/tools/tool.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.test.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use serde_json::Value;
 
@@ -258,24 +258,18 @@ async fn test_mount_file_in_mount() {
         .is_test(true)
         .try_init();
 
-    let test_file_path = PathBuf::from(format!(
-        "././shinkai-tools-runner-execution-storage/temp-test-files/{}",
-        nanoid::nanoid!()
-    ));
+    let test_file_path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
     std::fs::create_dir_all(test_file_path.parent().unwrap()).unwrap();
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
 
-    let execution_storage = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
-
     let js_code = r#"
         async function run (c, p) {
-            const files = [];
-            for await (const dirEntry of Deno.readDir(`${process.env.HOME}/mount`)) {
-                files.push(dirEntry.name);
+            const mount = Deno.env.get("MOUNT").split(',');
+            for await (const file of mount) {
+                console.log("file in mount: ", file);
             }
-            console.log("files in mount:", files);
-            const content = await Deno.readTextFile(`${process.env.HOME}/mount/${process.env.FILE_NAME}`);
+            const content = await Deno.readTextFile(mount[0]);
             console.log(content);
             return content;
         }
@@ -291,7 +285,6 @@ async fn test_mount_file_in_mount() {
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
-                storage: execution_storage.clone(),
                 mount_files: vec![test_file_path.to_path_buf().clone()],
                 ..Default::default()
             },
@@ -328,7 +321,8 @@ async fn test_mount_and_edit_file_in_mount() {
 
     let js_code = r#"
         async function run (c, p) {
-            await Deno.writeTextFile(`./mount/${process.env.FILE_NAME}`, "2");
+            const mount = Deno.env.get("MOUNT").split(',');
+            await Deno.writeTextFile(mount[0], "2");
             return;
         }
     "#;
@@ -379,18 +373,19 @@ async fn test_mount_file_in_assets() {
     println!("test file path: {:?}", test_file_path);
     std::fs::write(&test_file_path, "1").unwrap();
 
-    let execution_storage = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
-
-    let js_code = r#"
-        async function run (c, p) {
-            const content = await Deno.readTextFile(`./assets/${process.env.FILE_NAME}`);
-            console.log(content);
-            return content;
-        }
-    "#;
-
     let code_files = CodeFiles {
-        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            r#"
+                async function run (c, p) {
+                    const assets = Deno.env.get("ASSETS").split(',');
+                    const content = await Deno.readTextFile(assets[0]);
+                    console.log(content);
+                    return content;
+                }
+            "#
+            .to_string(),
+        )]),
         entrypoint: "main.ts".to_string(),
     };
 
@@ -399,7 +394,6 @@ async fn test_mount_file_in_assets() {
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
-                storage: execution_storage.clone(),
                 assets_files: vec![test_file_path.to_path_buf().clone()],
                 ..Default::default()
             },
@@ -410,7 +404,8 @@ async fn test_mount_file_in_assets() {
     envs.insert(
         "FILE_NAME".to_string(),
         test_file_path
-            .file_name()
+            .to_path_buf()
+            .canonicalize()
             .unwrap()
             .to_str()
             .unwrap()
@@ -434,26 +429,28 @@ async fn test_fail_when_try_write_assets() {
 
     let execution_storage = std::path::PathBuf::from("./shinkai-tools-runner-execution-storage");
 
-    let js_code = r#"
-        async function run (c, p) {
-            await Deno.writeTextFile(`${process.env.ASSETS}/${process.env.FILE_NAME}`);
-            return;
-        }
-    "#;
-
     let code_files = CodeFiles {
-        files: HashMap::from([("main.ts".to_string(), js_code.to_string())]),
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            r#"
+                async function run (c, p) {
+                    console.log('assetcitos', Deno.env.get("ASSETS"));
+                    const assets = Deno.env.get("ASSETS").split(',');
+                    await Deno.writeTextFile(assets[0], "2");
+                    return;
+                }
+            "#
+            .to_string(),
+        )]),
         entrypoint: "main.ts".to_string(),
     };
 
-    let context_id = format!("test-mount-file-in-assets-{}", nanoid::nanoid!());
     let tool = Tool::new(
         code_files,
         serde_json::Value::Null,
         Some(DenoRunnerOptions {
             context: ExecutionContext {
                 storage: execution_storage.clone(),
-                context_id: context_id.clone(),
                 code_id: "js_code".into(),
                 assets_files: vec![test_file_path.to_path_buf().clone()],
                 ..Default::default()
@@ -465,7 +462,8 @@ async fn test_fail_when_try_write_assets() {
     envs.insert(
         "FILE_NAME".to_string(),
         test_file_path
-            .file_name()
+            .to_path_buf()
+            .canonicalize()
             .unwrap()
             .to_str()
             .unwrap()
@@ -473,6 +471,11 @@ async fn test_fail_when_try_write_assets() {
     );
     let result = tool.run(Some(envs), Value::Null, None).await;
     assert!(result.is_err());
+    assert!(result
+        .clone()
+        .unwrap_err()
+        .to_string()
+        .contains("NotCapable"));
 }
 
 #[tokio::test]
@@ -556,7 +559,7 @@ async fn test_multiple_file_imports() {
 
     let tool = Tool::new(code_files, Value::Null, None);
     let result = tool.run(None, Value::Null, None).await;
-    
+
     assert!(result.is_ok());
     assert_eq!(result.unwrap().data, "processed test data");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shinkai_protocol/source",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shinkai_protocol/source",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@coinbase/coinbase-sdk": "^0.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinkai_protocol/source",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "This repository serves as the ecosystem to execute Shinkai tools, provided by the Shinkai team or third-party developers, in a secure environment. It provides a sandboxed space for executing these tools, ensuring that they run safely and efficiently, while also allowing for seamless integration with Rust code.",
   "main": "index.js",
   "author": "",


### PR DESCRIPTION
# Add support for mounting files and passing environment variables to Deno runner

This PR introduces several enhancements to the Deno runner in the shinkai-tools-runner library:

1. Added support for mounting files with read/write and read-only permissions into the Deno execution environment. This allows tools to access specific files during execution.

2. Implemented passing of environment variables to the Deno runner, including `MOUNT`, `ASSETS`, and `HOME`. These environment variables provide information about the mounted files and directories to the running tool.

3. Enhanced the Deno permissions system to grant appropriate access to mounted files, assets, and necessary directories for Playwright/Chrome.

4. Updated the example usage in the README to demonstrate how to set up and call a Shinkai tool from Rust, including passing input data, handling output, and specifying mounted files.

5. Improved logging and error handling in the DenoExecutionStorage and DenoRunner modules.

6. Renamed the `assets` field in the ExecutionContext struct to `assets_files` for clarity.

These changes improve the flexibility and usability of the shinkai-tools-runner library by allowing tools to access specific files and directories during execution. The updated example in the README provides a clear guide on how to leverage these new features when calling Shinkai tools from Rust.
