### PR TITLE
- faeture: add check method

### DIFF
--- a/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_execution_storage.rs
@@ -151,23 +151,24 @@ impl DenoExecutionStorage {
     }
 }
 
+// TODO: Validate if finally we are going to implement this feature
 // We do best effort to remove ephemereal folders
-impl Drop for DenoExecutionStorage {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_dir_all(&self.code_folder_path) {
-            log::warn!(
-                "failed to remove code directory {}: {}",
-                self.code_folder_path.display(),
-                e
-            );
-        } else {
-            log::info!(
-                "removed code directory: {}",
-                self.code_folder_path.display()
-            );
-        }
-    }
-}
+// impl Drop for DenoExecutionStorage {
+//     fn drop(&mut self) {
+//         if let Err(e) = std::fs::remove_dir_all(&self.code_folder_path) {
+//             log::warn!(
+//                 "failed to remove code directory {}: {}",
+//                 self.code_folder_path.display(),
+//                 e
+//             );
+//         } else {
+//             log::info!(
+//                 "removed code directory: {}",
+//                 self.code_folder_path.display()
+//             );
+//         }
+//     }
+// }
 
 #[cfg(test)]
 #[path = "deno_execution_storage.test.rs"]

--- a/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
+++ b/libs/shinkai-tools-runner/src/tools/deno_runner.test.rs
@@ -267,3 +267,134 @@ async fn test_run_with_imports() {
     let result = deno_runner.run(code_files, None, None).await.unwrap();
     assert_eq!(result.first().unwrap(), "hello world");
 }
+
+#[tokio::test]
+async fn test_check_code_success() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            String::from(
+                r#"
+                import { assertEquals } from "https://deno.land/std@0.201.0/assert/mod.ts";
+                console.log('test');
+            "#,
+            ),
+        )]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    // Run the code to ensure dependencies are downloaded
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        context: ExecutionContext {
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let check_result = deno_runner.check(code_files).await.unwrap();
+    assert_eq!(check_result.len(), 0);
+}
+
+#[tokio::test]
+async fn test_check_code_with_errors() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            String::from(
+                r#"
+                console.log('test's);
+            "#,
+            ),
+        )]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    // Run the code to ensure dependencies are downloaded
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        context: ExecutionContext {
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let check_result = deno_runner.check(code_files).await.unwrap();
+    assert!(!check_result.is_empty());
+    assert!(check_result.contains(&String::from("Expected ',', got 's'")));
+}
+
+#[tokio::test]
+async fn test_check_with_wrong_import_path() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            String::from(
+                r#"
+                import { a } from './potato/a.ts';
+                console.log('test');
+            "#,
+            ),
+        )]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    // Run the code to ensure dependencies are downloaded
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        context: ExecutionContext {
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let check_result = deno_runner.check(code_files).await.unwrap();
+    assert!(!check_result.is_empty());
+}
+
+#[tokio::test]
+async fn test_check_with_wrong_lib_version() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Info)
+        .is_test(true)
+        .try_init();
+
+    let code_files = CodeFiles {
+        files: HashMap::from([(
+            "main.ts".to_string(),
+            String::from(
+                r#"
+                import axios from 'npm:axios@3.4.2';
+                console.log('test');
+            "#,
+            ),
+        )]),
+        entrypoint: "main.ts".to_string(),
+    };
+
+    // Run the code to ensure dependencies are downloaded
+    let mut deno_runner = DenoRunner::new(DenoRunnerOptions {
+        context: ExecutionContext {
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let check_result = deno_runner.check(code_files).await.unwrap();
+    assert!(!check_result.is_empty());
+    assert!(check_result.contains(&String::from(
+        "Could not find npm package 'axios' matching '3.4.2'"
+    )));
+}

--- a/libs/shinkai-tools-runner/src/tools/tool.rs
+++ b/libs/shinkai-tools-runner/src/tools/tool.rs
@@ -80,6 +80,12 @@ impl Tool {
         Ok(tool_definition)
     }
 
+    pub async fn check(&self) -> anyhow::Result<Vec<String>> {
+        let mut deno_runner = DenoRunner::new(self.deno_runner_options.clone());
+        let code = self.code.clone();
+        deno_runner.check(code).await
+    }
+
     pub async fn run(
         &self,
         envs: Option<HashMap<String, String>>,


### PR DESCRIPTION
This PR introduces a new feature to check Deno code for errors before running it. The `DenoRunner` now has a `check` method that runs the `deno check` command and returns a list of errors if any are found.

Additionally, some minor updates were made:
- Commented out the `Drop` implementation for `DenoExecutionStorage` (to be revisited later)

New tests have been added to `deno_runner.test.rs` to cover the `check` functionality, including cases for successful checks, code with errors, wrong import paths, and incorrect library versions.