### PR TITLE
Switch from SHA256 to BLAKE3 hash.

### DIFF
--- a/.github/build_tool.sh
+++ b/.github/build_tool.sh
@@ -111,13 +111,13 @@ for tool_dir in tools/*/; do
             --header "Authorization: Bearer ${BEARER_TOKEN}" \
             --header 'Content-Type: application/json; charset=utf-8' > packages/${tool_name}.zip
 
-        # Generate a sha256 hash of the .zip file
-        sha256_hash=$(sha256sum packages/${tool_name}.zip | cut -d ' ' -f 1)
+        # Generate a blake3 hash of the .zip file
+        blake3_hash=$(b3sum packages/${tool_name}.zip | cut -d ' ' -f 1)
 
         # Add tool to directory.json
         # Create temporary file with updated content
-        jq --arg tool_name "$tool_name" --arg tool_router_key "$tool_router_key" --arg description "$tool_description" --arg sha256_hash "$sha256_hash" --arg file "$DOWNLOAD_PREFIX/$tool_name.zip" \
-            '. += [{name: $tool_name, description: $description, router_key: $tool_router_key, sha256: $sha256_hash, file: $file}]' packages/directory.json > packages/directory.json.tmp
+        jq --arg tool_name "$tool_name" --arg tool_router_key "$tool_router_key" --arg description "$tool_description" --arg blake3_hash "$blake3_hash" --arg file "$DOWNLOAD_PREFIX/$tool_name.zip" \
+            '. += [{name: $tool_name, description: $description, router_key: $tool_router_key, hash: $blake3_hash, file: $file}]' packages/directory.json > packages/directory.json.tmp
         # Replace original file with temporary file
         mv packages/directory.json.tmp packages/directory.json
     fi

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -15,6 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Install b3sum
+        run: cargo install b3sum
+
       - name: Install dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
This pull request includes changes to the hashing mechanism in the build script and updates to the GitHub Actions workflow. The most important changes include switching from SHA-256 to Blake3 for file hashing and installing necessary tools in the CI pipeline.

Changes to hashing mechanism:

* [`.github/build_tool.sh`](diffhunk://#diff-0baa86d70143c74fae8c4d9ea61e944e989aa7e0933359d267d0c3a8d2225e73L114-R120): Changed the hashing algorithm from SHA-256 to Blake3 for generating file hashes and updated the JSON key accordingly.

Updates to GitHub Actions workflow:

* [`.github/workflows/build_tools.yaml`](diffhunk://#diff-3c29dd0ba4c3527a0384733964f46377bb9e36af318095b4cebdde8ce656f51eR18-R26): Added steps to install Rust and the `b3sum` tool required for Blake3 hashing.